### PR TITLE
Add missing import for `logger` package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tube
 Type: Package
 Title: Access Ellipse Data Hub on AWS
-Version: 0.0.1.9004
+Version: 0.0.1.9005
 Authors@R:
   c(person(
       given = "Patrick",
@@ -25,6 +25,7 @@ Imports:
     cli,
     DBI,
     dplyr,
+    logger,
     magrittr,
     memoise,
     noctua,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
-# tube (development version)
+# tube 0.0.1.9005
+
+* Add missing import for `logger`
+
+# tube 0.0.1.9004
 
 * Change behavior of `ellipse_partitions`
 


### PR DESCRIPTION
La dépendance envers `logger` n'était pas déclarée dans `DESCRIPTION`, ce qui faisait en sorte que les fonctions qui requièrent ce package échouaient s'il n'était pas installé.