### PR TITLE
Support DEV or PROD in ellipse_connect()

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,4 @@
+linters: linters_with_defaults(
+    line_length_linter(120),
+    commented_code_linter = NULL
+  )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tube
 Type: Package
 Title: Access Ellipse Data Hub on AWS
-Version: 0.0.11
+Version: 0.0.12
 Authors@R:
   c(person(
       given = "Patrick",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# tube 0.0.12
+
+* `ellipse_connect()` can now connect to DEV or PROD environments
+* `ellipse_connect()` now has a `database` parameter for Glue/Athena
+
 # tube 0.0.11
 
 # tube 0.0.10

--- a/R/ellipse.R
+++ b/R/ellipse.R
@@ -7,25 +7,56 @@ memoized_aws_session <- memoise::memoise(aws_session)
 #'
 #' @returns Un object de connexion `DBI`.
 #' @export
-ellipse_connect <- function() {
-  aws_access_key_id     <- Sys.getenv("AWS_ACCESS_KEY_ID")
-  aws_secret_access_key <- Sys.getenv("AWS_SECRET_ACCESS_KEY")
+ellipse_connect <- function(
+  env = c("PROD", "DEV"),
+  database  = "datawarehouse"
+) {
+  env <- match.arg(env)
+  cli::cli_alert_info(paste("Environnement:", env))
+
+  aws_access_key_id <-
+    switch(env,
+           "PROD" = "AWS_ACCESS_KEY_ID_PROD",
+           "DEV"  = "AWS_ACCESS_KEY_ID_DEV") |>
+    Sys.getenv()
+
+  aws_secret_access_key <-
+    switch(env,
+           "PROD" = "AWS_SECRET_ACCESS_KEY_PROD",
+           "DEV"  = "AWS_SECRET_ACCESS_KEY_DEV") |>
+    Sys.getenv()
+
+  # https://github.com/ellipse-science/tube/issues/16
+  Sys.setenv("AWS_ACCESS_KEY_ID" = aws_access_key_id)
+  Sys.setenv("AWS_SECRET_ACCESS_KEY" = aws_secret_access_key)
+
   if (aws_access_key_id == "" || aws_secret_access_key == "") {
     usage <-
       paste("On a besoin de vos clés d'accès sur AWS pour se connecter!\n\n",
             "Dans le fichier ~/.Renviron, ajoutez les lignes:\n\n",
-            "AWS_ACCESS_KEY_ID=<votre access key id>\n",
-            "AWS_SECRET_ACCESS_KEY=<votre secret access key>\n\n",
+            "AWS_ACCESS_KEY_ID_PROD=<votre access key id de production>\n",
+            "AWS_SECRET_ACCESS_KEY_PROD=<votre secret access key de production>\n",
+            "AWS_ACCESS_KEY_ID_DEV=<votre access key id de développement>\n",
+            "AWS_SECRET_ACCESS_KEY_DEV=<votre secret access key de développement>\n\n",
             "Puis, redémarrez la session R.")
     cli::cli_alert_danger(usage)
     return(NULL)
   }
-  session <- memoized_aws_session()
+  database <- match.arg(database)
+  cli::cli_alert_info(paste("Database:", database))
+
+  session <- memoized_aws_session(id = aws_access_key_id,
+                                  key = aws_secret_access_key)
+  schema_name <- switch(database,
+                        "datawarehouse" = paste0(session$datawarehouse_database),
+                        database)
+
   cli::cli_alert_info("Pour déconnecter: DBI::dbDisconnect(objet_de_connexion)")
   DBI::dbConnect(noctua::athena(),
                  aws_access_key_id = aws_access_key_id,
                  aws_secret_access_key = aws_secret_access_key,
-                 schema_name = session$datawarehouse_database,
+                 schema_name = schema_name,
+                 work_group = "ellipse-work-group",
                  s3_staging_dir = paste0("s3://",
                                          session$athena_staging_bucket))
 

--- a/R/ellipse.R
+++ b/R/ellipse.R
@@ -5,16 +5,21 @@ memoized_aws_session <- memoise::memoise(aws_session)
 #' Cette fonction utilise les clés d'accès AWS configurées dans le fichier
 #' `.Renviron` pour se connecter à la plateforme de données.
 #'
-#' @param env The environment to connect to on ellipse-science. Defaults to "PROD"
+#' @param env The environment to connect to on ellipse-science. Accepted values are "PROD" and "DEV".
 #' @param database The Glue/Athena database to connect to. Default to "datawarehouse"
 #'
 #' @returns Un object de connexion `DBI`.
 #' @export
 ellipse_connect <- function(
-  env = c("PROD", "DEV"),
+  env = NULL,
   database  = "datawarehouse"
 ) {
-  env <- match.arg(env)
+  if (is.null(env)) {
+    cli::cli_alert_danger(paste("Oups, il faut choisir un environnement! 😅\n\n",
+                                "Le paramètre `env` peut être \"PROD\" ou \"DEV\"",
+                                sep = ""))
+    return(NULL)
+  }
   cli::cli_alert_info(paste("Environnement:", env))
 
   aws_access_key_id <-

--- a/R/ellipse.R
+++ b/R/ellipse.R
@@ -5,6 +5,9 @@ memoized_aws_session <- memoise::memoise(aws_session)
 #' Cette fonction utilise les clés d'accès AWS configurées dans le fichier
 #' `.Renviron` pour se connecter à la plateforme de données.
 #'
+#' @param env The environment to connect to on ellipse-science. Defaults to "PROD"
+#' @param database The Glue/Athena database to connect to. Default to "datawarehouse"
+#'
 #' @returns Un object de connexion `DBI`.
 #' @export
 ellipse_connect <- function(

--- a/R/tools.R
+++ b/R/tools.R
@@ -98,7 +98,7 @@ list_glue_databases <- function(type, credentials) {
 }
 
 #' @export
-list_glue_tables <- function(type, datamart = NULL, credentials) {  
+list_glue_tables <- function(type, datamart = NULL, credentials) {
   logger::log_debug("[tube::list_glue_tables] entering function")
   table_list <- list()
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Ensuite, il faut les ajouter au fichier `~/.Renviron` qui est chargé au démarr
 * macOS : `/Users/<votre utilisateur>/.Renviron`
 * Linux : `/home/<votre utilisateur>/.Renviron`
 
-Il existe deux environnement (deux copies non identiques) de la plateforme de données sur AWS.  
+Il existe deux environnement (deux copies non identiques) de la plateforme de données sur AWS.
 
 * Une copie de développement (DEV) dans laquelle on développe les pipelines et où on conçoit les structure des données (tables, variables etc.).  Vous allez principalement vous connecter en DEV pour valider le travail des développeurs et la structure de données que leur pipelines va générer, en faisant des tests les plus réels possible selon vos projets de recherche, sur des petits échantillons de données.
 * Une copie de PROD: Lorsqu'on est satisfait avec la conception, on passe en production (PROD). Là les données sont officielles, de qualité en tout temps, dans leur structure approuvée (par vous en DEV).
 
-Pour se connecter à l'un ou l'autre des environnements, il faut le choisir au moment de la connection.  Pour cela, il faut configurer 2 paires "ID de clé"+"Secret de clé" comme suit: 
+Pour se connecter à l'un ou l'autre des environnements, il faut le choisir au moment de la connection.  Pour cela, il faut configurer 2 paires "ID de clé"+"Secret de clé" comme suit:
 
 ```R
 # .Renviron
@@ -52,12 +52,14 @@ Des efforts sont déployés pour documenter les différentes fonctions fournies 
 
 ### Se connecter
 
-Pour se connecter, utiliser la fonction `ellipse_connect()` :
+Pour se connecter, utiliser la fonction `ellipse_connect()`. Le seul paramètre obligatoire est l'environnement (`DEV` ou `PROD`) :
 
 ```R
 [ins] r$> library(tube)
 
-[ins] r$> con <- ellipse_connect()
+[ins] r$> con <- ellipse_connect(env = "PROD")
+ℹ Environnement: PROD
+ℹ Database: datawarehouse
 ℹ Pour déconnecter: DBI::dbDisconnect(objet_de_connexion)
 ```
 

--- a/man/ellipse_connect.Rd
+++ b/man/ellipse_connect.Rd
@@ -4,7 +4,12 @@
 \alias{ellipse_connect}
 \title{Se connecter à la plateforme de données ellipse sur AWS}
 \usage{
-ellipse_connect()
+ellipse_connect(env = c("PROD", "DEV"), database = "datawarehouse")
+}
+\arguments{
+\item{env}{The environment to connect to on ellipse-science. Defaults to "PROD"}
+
+\item{database}{The Glue/Athena database to connect to. Default to "datawarehouse"}
 }
 \value{
 Un object de connexion \code{DBI}.

--- a/man/upload_to_landing_zone.Rd
+++ b/man/upload_to_landing_zone.Rd
@@ -4,7 +4,7 @@
 \alias{upload_to_landing_zone}
 \title{Uploads the files in the specified local folder to the landing zone bucket.  The landing zone takes a maximum of 30 files
 at a time.  If your local_folder contains more than 30 files, the files will be segmented into sets of 30 files and uploaded
-one set at a time.  The function will wait 6 minutes between each set to ensure that the data platform has time to process the files.
+one set at a time.  The function will wait 10 minutes between each set to ensure that the data platform has time to process the files.
 Please ensure that your pipeline has been configured by your data platform administrator before uploading data to the landing zone, otherwise
 the function will return an error message.}
 \usage{
@@ -34,7 +34,7 @@ the status of each file upload
 \description{
 Uploads the files in the specified local folder to the landing zone bucket.  The landing zone takes a maximum of 30 files
 at a time.  If your local_folder contains more than 30 files, the files will be segmented into sets of 30 files and uploaded
-one set at a time.  The function will wait 6 minutes between each set to ensure that the data platform has time to process the files.
+one set at a time.  The function will wait 10 minutes between each set to ensure that the data platform has time to process the files.
 Please ensure that your pipeline has been configured by your data platform administrator before uploading data to the landing zone, otherwise
 the function will return an error message.
 }


### PR DESCRIPTION
Cette PR permet de choisir l'environnement (DEV ou PROD) lors de la connexion avec `ellipse_connect()`. L'environnement de production est utilisé par défaut.

Un paramètre `database` a également été ajouté pour choisir la base de données Glue/Athena dans l'optique où un jour on va se connecter à des datamarts. La valeur par défaut est `datawarehouse`, qui map à `aws_session()["datawarehouse_database"]`.

## Exemples de connexion

```r
[ins] r$> con <- ellipse_connect()
ℹ Environnement: PROD
ℹ Database: datawarehouse
ℹ Pour déconnecter: DBI::dbDisconnect(objet_de_connexion)

[ins] r$> ellipse_discover(con)
# A tibble: 5 × 2
  categorie table              
  <chr>     <chr>              
1 Agora+    a-qc-press-releases
2 Dimension dim-medias         
3 Radar+    r-factiva          
4 Radar+    r-media-frontpages 
5 Radar+    r-media-headlines  

[ins] r$> con_dev <- ellipse_connect(env = "DEV")
ℹ Environnement: DEV
ℹ Database: datawarehouse
ℹ Pour déconnecter: DBI::dbDisconnect(objet_de_connexion)

[ins] r$> ellipse_discover(con_dev)
# A tibble: 20 × 2
   categorie    table                                
   <chr>        <chr>                                
 1 Agora+       a-ca-parliament-debates              
 2 Agora+       a-ca-press-releases                  
 3 Agora+       a-eu-parliament-debates              
 4 Agora+       a-humans                             
 5 Agora+       a-qc-parliament-debates              
 6 Agora+       a-qc-press-releases                  
 7 Dictionnaire dict-issues                          
 8 Dictionnaire dict-political-parties-can           
 9 Dictionnaire dict-political-parties-qc            
10 Dictionnaire dict-sentiments                      
11 Dimension    dim-institutions                     
12 Dimension    dim-medias                           
13 Dimension    dim-parliament-members               
14 Dimension    dim-parties                          
15 Radar+       r-factiva                            
16 Radar+       r-media-frontpages                   
17 Radar+       r-media-headlines                    
18 Autre        test-datamart-csv_unprocessed        
19 Autre        test2-datamart_partition1_unprocessed
20 Autre        test2-datamart_partition2_unprocessed

[ins] r$> DBI::dbDisconnect(con)

[ins] r$> DBI::dbDisconnect(con_dev)
```

## Note for future me

J'ai ajouté ceci en lien avec #16:

https://github.com/ellipse-science/tube/blob/acbb246ed883ace18ad8c4d7b4b60f65646da4c7/R/ellipse.R#L32-L34

Ça fonctionne mais ce n'est pas idéal d'avoir une fonction qui modifie l'environnement de l'utilisateur.