### PR TITLE
Fix error overwriting existing table when publishing.

### DIFF
--- a/R/ellipse.R
+++ b/R/ellipse.R
@@ -484,7 +484,7 @@ ellipse_publish <- function(
       r2 <- delete_s3_folder(creds, dm_bucket, paste0(datamart, "/", table))
       r3 <- delete_s3_folder(creds, dm_bucket, paste0(datamart, "/", table, "-output"))
 
-      if (r1 && r2 && r3) {
+      if (r1 || (r2 && r3)) {
         cli::cli_alert_success("La table a été écrasée avec succès.")
       } else {
         cli::cli_alert_danger("Il y a eu une erreur lors de la suppression de la table dans la datamart! 😅")


### PR DESCRIPTION
Cette PR vise à régler l'issue https://github.com/ellipse-science/tube/issues/42

Le problème est que si on publie initialement un dataframe et que le processus de publication (Glue Job) échoue, lorsqu'on réessaie de publier la même table, la fonction n'est pas en mesure de supprimer la table glue avec succès puisqu'elle n'existe pas.

<img width="522" alt="Capture d’écran, le 2024-07-30 à 07 59 24" src="https://github.com/user-attachments/assets/234d9a30-a316-433c-aaca-57c8b5a6331b">
